### PR TITLE
Disable time stepping for low-flying sub-orbital vessels

### DIFF
--- a/Client/TimeSyncer.cs
+++ b/Client/TimeSyncer.cs
@@ -198,8 +198,16 @@ namespace DarkMultiPlayer
                     }
                 case Vessel.Situations.ORBITING:
                 case Vessel.Situations.ESCAPING:
-                case Vessel.Situations.SUB_ORBITAL:
                     return true;
+                case Vessel.Situations.SUB_ORBITAL:
+                    if (checkVessel.altitude < 10000) 
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 default :
                     return false;
             }


### PR DESCRIPTION
When moving things around on the surface, if the framerate drops then DMP will try to step time to resync, but sometimes this causes things to teleport into the ground. There's a video of this happening here: http://youtu.be/QbmQ8vripRk
