### PR TITLE
Prompt the Windows user to run the server as an administrator

### DIFF
--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -180,7 +180,7 @@ namespace DarkMultiPlayerServer
         public int screenshotsPerPlayer = 20;
         public int screenshotHeight = 720;
         public bool cheats = true;
-        public int httpPort = 8081;
+        public int httpPort = 0;
         public string serverName = "DMP Server";
         public int maxPlayers = 20;
         public string screenshotDirectory = "";


### PR DESCRIPTION
Added #142.

If Windows OS then it won't show the access denied exception, but
instead, will debug a message, and prompt the user to run to server as
an administrator.

httpPort default is set to 0.

Also added a name to the console window. Which is DMPServer +
PROGRAM_VERSION + ", protocol " + PROTOCOL_VERSION
