### PR TITLE
Reset handled=false before calling plugins

### DIFF
--- a/Server/ClientHandler.cs
+++ b/Server/ClientHandler.cs
@@ -852,6 +852,7 @@ namespace DarkMultiPlayerServer
         #region Message handling
         private static void HandleMessage(ClientObject client, ClientMessage message)
         {
+            message.handled = false;
             DMPPluginHandler.FireOnMessageReceived(client, message);
 
             if (message.handled)

--- a/Server/DMPPluginHandler.cs
+++ b/Server/DMPPluginHandler.cs
@@ -227,6 +227,7 @@ namespace DarkMultiPlayerServer
             {
                 try
                 {
+                    message.handled = false;
                     plugin.OnMessageReceived(client, message);
 
                     //prevent plugins from unhandling other plugin's handled requests


### PR DESCRIPTION
Need to set handled=true otherwise once the ClientMessage is set to handled, it'll never be unhandled because it reuses the same ClientMessage for later messages.

I'm not sure how this ever worked at all but seemed to happen only in specific conditions.
