### PR TITLE
Admin Chat Commands

### DIFF
--- a/Client/ChatWorker.cs
+++ b/Client/ChatWorker.cs
@@ -325,6 +325,17 @@ namespace DarkMultiPlayer
                             {
                                 NetworkWorker.fetch.SendMotdRequest();
                             }
+                            if (sendText.StartsWith("/admcmd ") && sendText.Length > 9)
+                            {
+                                string admcmd = sendText.Substring(8);
+                                using (MessageWriter mw = new MessageWriter())
+                                {
+                                    mw.Write<int>((int)ChatMessageType.ADMIN_CMD_MESSAGE);
+                                    mw.Write<string>(Settings.fetch.playerName);
+                                    mw.Write<string>(admcmd);
+                                    NetworkWorker.fetch.SendChatMessage(mw.GetMessageBytes());
+                                }
+                            }
                         }
                     }
                     sendText = "";

--- a/Common/Common.cs
+++ b/Common/Common.cs
@@ -480,6 +480,7 @@ namespace DarkMultiPlayerCommon
         LEAVE,
         CHANNEL_MESSAGE,
         PRIVATE_MESSAGE,
+        ADMIN_CMD_MESSAGE,
     }
 
     public enum LockMessageType

--- a/Server/ClientHandler.cs
+++ b/Server/ClientHandler.cs
@@ -1277,6 +1277,20 @@ namespace DarkMultiPlayerServer
                             }
                         }
                         break;
+                    case ChatMessageType.ADMIN_CMD_MESSAGE:
+                        {
+                            string admcmd = mr.Read<string>();
+                            if(serverAdmins.Contains(fromPlayer))
+                            {
+                                CommandHandler.HandleCommand("/" + admcmd);
+                                DarkLog.ChatMessage("Admin player " + fromPlayer + " ran server command " + admcmd);
+                            }
+                            else
+                            {
+                                DarkLog.ChatMessage("Unprivileged user " + fromPlayer + " tried to run admin command " + admcmd);
+                            }
+                        }
+                        break;
                 }
             }
         }

--- a/Server/CommandHandler.cs
+++ b/Server/CommandHandler.cs
@@ -43,44 +43,7 @@ namespace DarkMultiPlayerServer
                         Thread.Sleep(500);
                     }
                     DarkLog.Normal("Command input: " + input);
-                    if (input.StartsWith("/"))
-                    {
-                        string commandPart = input.Substring(1);
-                        string argumentPart = "";
-                        if (commandPart.Contains(" "))
-                        {
-                            if (commandPart.Length > commandPart.IndexOf(' ') + 1)
-                            {
-                                argumentPart = commandPart.Substring(commandPart.IndexOf(' ') + 1);
-                            }
-                            commandPart = commandPart.Substring(0, commandPart.IndexOf(' '));
-                        }
-                        if (commandPart.Length > 0)
-                        {
-                            if (commands.ContainsKey(commandPart))
-                            {
-                                try
-                                {
-                                    commands[commandPart].func(argumentPart);
-                                }
-                                catch (Exception e)
-                                {
-                                    DarkLog.Error("Error handling command " + commandPart + ", Exception " + e);
-                                }
-                            }
-                            else
-                            {
-                                DarkLog.Normal("Unknown command: " + commandPart);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        if (input != "")
-                        {
-                            commands["say"].func(input);
-                        }
-                    }
+                    HandleCommand(input);
                 }
             }
             catch (Exception e)
@@ -89,6 +52,48 @@ namespace DarkMultiPlayerServer
                 {
                     DarkLog.Fatal("Error in command handler thread, Exception: " + e);
                     throw;
+                }
+            }
+        }
+
+        public static void HandleCommand(string input)
+        {
+            if (input.StartsWith("/"))
+            {
+                string commandPart = input.Substring(1);
+                string argumentPart = "";
+                if (commandPart.Contains(" "))
+                {
+                    if (commandPart.Length > commandPart.IndexOf(' ') + 1)
+                    {
+                        argumentPart = commandPart.Substring(commandPart.IndexOf(' ') + 1);
+                    }
+                    commandPart = commandPart.Substring(0, commandPart.IndexOf(' '));
+                }
+                if (commandPart.Length > 0)
+                {
+                    if (commands.ContainsKey(commandPart))
+                    {
+                        try
+                        {
+                            commands[commandPart].func(argumentPart);
+                        }
+                        catch (Exception e)
+                        {
+                            DarkLog.Error("Error handling command " + commandPart + ", Exception " + e);
+                        }
+                    }
+                    else
+                    {
+                        DarkLog.Normal("Unknown command: " + commandPart);
+                    }
+                }
+            }
+            else
+            {
+                if (input != "")
+                {
+                    commands["say"].func(input);
                 }
             }
         }


### PR DESCRIPTION
Added a command pipe for admin commands. Properly authenticates Admin
players and logs failed attempts. Run command with '/admcmd' from chat.
