### PR TITLE
Fixed a bug where HttpServer would throw on server restart.

### DIFF
--- a/Server/Main.cs
+++ b/Server/Main.cs
@@ -345,8 +345,7 @@ namespace DarkMultiPlayerServer
                 {
                     try
                     {
-                        httpListener.Stop();
-                        httpListener.Close();
+                        httpListener.Abort();
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
I've changed to `httpListener.Abort()` on Server.Restart because we need to abort it to make sure the HTTP server will run successfully after the restart.
