### PR TITLE
Trim Server address field

### DIFF
--- a/Client/ConnectionWindow.cs
+++ b/Client/ConnectionWindow.cs
@@ -177,7 +177,7 @@ namespace DarkMultiPlayer
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Name:", labelOptions);
-                serverName = GUILayout.TextArea(serverName, textAreaStyle);
+                serverName = GUILayout.TextArea(serverName, textAreaStyle).Trim();
                 GUILayout.EndHorizontal();
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Address:", labelOptions);


### PR DESCRIPTION
Why not trim the server name field too?
It messes up the entire server list.
