### PR TITLE
Set freeID when creating new subspace lock file.

### DIFF
--- a/Server/Messages/WarpControl.cs
+++ b/Server/Messages/WarpControl.cs
@@ -659,6 +659,7 @@ namespace DarkMultiPlayerServer.Messages
                 newSubspace.subspaceSpeed = 1f;
                 subspaces.Add(0, newSubspace);
                 SaveSubspace(0, newSubspace);
+                freeID = 1;
             }
         }
 


### PR DESCRIPTION
Not setting this causes issues with players warping after a server is created. See #305