### PR TITLE
Messages: fix SERVER_SETTINGS missage by adding missing fields.

### DIFF
--- a/Server/Messages/ServerSettings.cs
+++ b/Server/Messages/ServerSettings.cs
@@ -34,6 +34,8 @@ namespace DarkMultiPlayerServer.Messages
                     mw.Write<bool>(GameplaySettings.settingsStore.bypassEntryPurchaseAfterResearch);
                     mw.Write<bool>(GameplaySettings.settingsStore.indestructibleFacilities);
                     mw.Write<bool>(GameplaySettings.settingsStore.missingCrewsRespawn);
+                    mw.Write<float>(GameplaySettings.settingsStore.reentryHeatScale);
+                    mw.Write<float>(GameplaySettings.settingsStore.resourceAbundance);
                     mw.Write<float>(GameplaySettings.settingsStore.fundsGainMultiplier);
                     mw.Write<float>(GameplaySettings.settingsStore.fundsLossMultiplier);
                     mw.Write<float>(GameplaySettings.settingsStore.repGainMultiplier);


### PR DESCRIPTION
The fields reentryHeatScale and resourceAbundance were not sent to the
client, so it would fail to connect in version 0.2.2.1.