### PR TITLE
Default map filter

### DIFF
--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -621,7 +621,10 @@ namespace DarkMultiPlayer
 
             //Flightstate is null on new Game();
             returnGame.flightState = new FlightState();
-            returnGame.flightState.mapViewFilterState = -1026; // set the map filter to the default value.
+            if (returnGame.flightState.mapViewFilterState == 0)
+            {
+                returnGame.flightState.mapViewFilterState = -1026; // set the map filter to the default value.
+            }
 
             //DMP stuff
             returnGame.startScene = GameScenes.SPACECENTER;

--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -621,6 +621,7 @@ namespace DarkMultiPlayer
 
             //Flightstate is null on new Game();
             returnGame.flightState = new FlightState();
+            returnGame.flightState.mapViewFilterState = -1026; // set the map filter to the default value.
 
             //DMP stuff
             returnGame.startScene = GameScenes.SPACECENTER;


### PR DESCRIPTION
Set the FlightState.mapViewFilterState to default at -1026.  This value
maps to all categories except debris and flags being visible.  For some
reason, this caused an occasional issue where no vessels would be
visible in the tracking station even though the filter buttons were
correctly highlighted.  The temporary work around was to fly a vessel,
or toggle any of the buttons manually, and then vessels would be visible
again.