### PR TITLE
Fix 1.2 compile error due to parameter name change.

### DIFF
--- a/Client/NetworkWorker.cs
+++ b/Client/NetworkWorker.cs
@@ -1088,8 +1088,7 @@ namespace DarkMultiPlayer
                     newParameters.Difficulty.EnableCommNet = mr.Read<bool>();
                     newParameters.CustomParams<GameParameters.AdvancedParams>().EnableKerbalExperience = mr.Read<bool>();
                     newParameters.CustomParams<GameParameters.AdvancedParams>().ImmediateLevelUp = mr.Read<bool>();
-                    newParameters.CustomParams<GameParameters.AdvancedParams>().AllowNegativeFunds = mr.Read<bool>();
-                    newParameters.CustomParams<GameParameters.AdvancedParams>().AllowNegativeScience = mr.Read<bool>();
+                    newParameters.CustomParams<GameParameters.AdvancedParams>().AllowNegativeCurrency = mr.Read<bool>();
                     newParameters.CustomParams<GameParameters.AdvancedParams>().ResourceTransferObeyCrossfeed = mr.Read<bool>();
                     newParameters.CustomParams<GameParameters.AdvancedParams>().BuildingImpactDamageMult = mr.Read<float>();
                     newParameters.CustomParams<GameParameters.AdvancedParams>().PartUpgradesInCareer = newAdvancedParameters.PartUpgradesInSandbox = mr.Read<bool>();


### PR DESCRIPTION
As of 1.2.0, parameters AllowNegativeFunds and AllowNegativeScience have been merged into a single option AllowNegativeCurrency., causing compile errors in NetworkWorker.cs.