### PR TITLE
Create and save kerbals and vessels for preexisting rescue contracts

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -30,15 +30,15 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <Reference Include="System" />
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\Assembly-CSharp.dll</HintPath>
+      <HintPath>P:\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\UnityEngine.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>P:\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="MessageWriter2">
       <HintPath>..\MessageWriter2.dll</HintPath>
@@ -46,12 +46,12 @@
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>..\UnityEngine.UI.dll</HintPath>
+    <Reference Include="UnityEngine">
+      <HintPath>P:\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\Assembly-CSharp-firstpass.dll</HintPath>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>P:\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -30,15 +30,15 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>P:\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>P:\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>..\UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="MessageWriter2">
       <HintPath>..\MessageWriter2.dll</HintPath>
@@ -46,12 +46,12 @@
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>P:\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>..\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>P:\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.UI.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Client/NetworkWorker.cs
+++ b/Client/NetworkWorker.cs
@@ -1763,7 +1763,7 @@ namespace DarkMultiPlayer
                     return true;
                 }
             }
-            
+
             return false;
         }
 
@@ -1776,18 +1776,27 @@ namespace DarkMultiPlayer
                 DarkLog.Debug("Vessel " + vessel.vesselID + " has NaN position");
                 return;
             }
+            bool isContractVessel = false;
+            //TODO: Detect "rescue" crafts via the discovery info. Not sure why the hell it's a confignode though.
+            //if (vessel.vesselType
             foreach (ProtoPartSnapshot pps in vessel.protoPartSnapshots)
             {
                 foreach (ProtoCrewMember pcm in pps.protoModuleCrew.ToArray())
                 {
-                    if (pcm.type == ProtoCrewMember.KerbalType.Tourist)
+                    if (pcm.type == ProtoCrewMember.KerbalType.Tourist || pcm.type == ProtoCrewMember.KerbalType.Unowned)
                     {
-                        pps.protoModuleCrew.Remove(pcm);
+                        isContractVessel = true;
                     }
                 }
             }
             ConfigNode vesselNode = new ConfigNode();
             vessel.Save(vesselNode);
+            if (isContractVessel)
+            {
+                ConfigNode dmpNode = new ConfigNode();
+                dmpNode.AddValue("contractOwner", Settings.fetch.playerName);
+                vesselNode.AddNode("DMP", dmpNode);
+            }
             ClientMessage newMessage = new ClientMessage();
             newMessage.type = ClientMessageType.VESSEL_PROTO;
             byte[] vesselBytes = ConfigNodeSerializer.fetch.Serialize(vesselNode);
@@ -2063,4 +2072,3 @@ namespace DarkMultiPlayer
         public int port;
     }
 }
-

--- a/Client/VesselWorker.cs
+++ b/Client/VesselWorker.cs
@@ -1575,7 +1575,6 @@ namespace DarkMultiPlayer
 
         public void OnVesselDestroyed(Vessel dyingVessel)
         {
-            //DarkLog.Debug("VesselWorker.OnVesselDestroyed: " + dyingVessel.vesselName);
             Guid dyingVesselID = dyingVessel.id;
             //Docking destructions
             if (dyingVesselID == fromDockedVesselID || dyingVesselID == toDockedVesselID)
@@ -1656,7 +1655,6 @@ namespace DarkMultiPlayer
 		//TODO: I don't know what this bool does?
         public void OnVesselRecovered(ProtoVessel recoveredVessel, bool something)
         {
-            DarkLog.Debug("VesselWorker.OnVesselRecovered");
             Guid recoveredVesselID = recoveredVessel.vesselID;
 
             if (LockSystem.fetch.LockExists("control-" + recoveredVesselID) && !LockSystem.fetch.LockIsOurs("control-" + recoveredVesselID))
@@ -1685,7 +1683,6 @@ namespace DarkMultiPlayer
 
         public void OnVesselTerminated(ProtoVessel terminatedVessel)
         {
-            DarkLog.Debug("VesselWorker.OnVesselTerminated");
             Guid terminatedVesselID = terminatedVessel.vesselID;
             //Check the vessel hasn't been changed in the future
             if (LockSystem.fetch.LockExists("control-" + terminatedVesselID) && !LockSystem.fetch.LockIsOurs("control-" + terminatedVesselID))

--- a/Client/VesselWorker.cs
+++ b/Client/VesselWorker.cs
@@ -877,6 +877,11 @@ namespace DarkMultiPlayer
 
         public void SendVesselUpdateIfNeeded(Vessel checkVessel)
         {
+            if (checkVessel == null)
+            {
+                DarkLog.Debug("Skipping sending null vessel reference");
+                return;
+            }
             //Check vessel parts
             if (ModWorker.fetch.modControl != ModControlMode.DISABLED)
             {
@@ -973,10 +978,10 @@ namespace DarkMultiPlayer
 
         public void SendKerbalIfDifferent(ProtoCrewMember pcm)
         {
-            if (pcm.type == ProtoCrewMember.KerbalType.Tourist || pcm.type == ProtoCrewMember.KerbalType.Unowned)
+            if (pcm.type == ProtoCrewMember.KerbalType.Tourist || (pcm.type == ProtoCrewMember.KerbalType.Unowned && pcm.rosterStatus == ProtoCrewMember.RosterStatus.Assigned))
             {
-                //Don't send tourists or unowned Kerbals (rescue)
-                DarkLog.Debug("Skipping sending of tourist/unowned: " + pcm.name);
+                //Don't send tourists/assigned & unowned kerbals (rescues)
+                DarkLog.Debug("Skipping sending of tourist or stranded: " + pcm.name);
                 return;
             }
             ConfigNode kerbalNode = new ConfigNode();

--- a/Client/VesselWorker.cs
+++ b/Client/VesselWorker.cs
@@ -48,10 +48,10 @@ namespace DarkMultiPlayer
         private Dictionary<Guid, bool> vesselPartsOk = new Dictionary<Guid, bool>();
         //Vessel state tracking
         private Guid lastVesselID;
-        private Dictionary <Guid, int> vesselPartCount = new Dictionary<Guid, int>();
-        private Dictionary <Guid, string> vesselNames = new Dictionary<Guid, string>();
-        private Dictionary <Guid, VesselType> vesselTypes = new Dictionary<Guid, VesselType>();
-        private Dictionary <Guid, Vessel.Situations> vesselSituations = new Dictionary<Guid, Vessel.Situations>();
+        private Dictionary<Guid, int> vesselPartCount = new Dictionary<Guid, int>();
+        private Dictionary<Guid, string> vesselNames = new Dictionary<Guid, string>();
+        private Dictionary<Guid, VesselType> vesselTypes = new Dictionary<Guid, VesselType>();
+        private Dictionary<Guid, Vessel.Situations> vesselSituations = new Dictionary<Guid, Vessel.Situations>();
         //Known kerbals
         private Dictionary<string, string> serverKerbals = new Dictionary<string, string>();
         //Known vessels and last send/receive time
@@ -177,7 +177,7 @@ namespace DarkMultiPlayer
                         delayKillVessels.Remove(dyingVessel);
                     }
                 }
-                
+
                 if (fromDockedVesselID != Guid.Empty || toDockedVesselID != Guid.Empty)
                 {
                     HandleDocking();
@@ -877,11 +877,6 @@ namespace DarkMultiPlayer
 
         public void SendVesselUpdateIfNeeded(Vessel checkVessel)
         {
-            if (checkVessel == null)
-            {
-                DarkLog.Debug("Skipping sending null vessel reference");
-                return;
-            }
             //Check vessel parts
             if (ModWorker.fetch.modControl != ModControlMode.DISABLED)
             {
@@ -978,14 +973,14 @@ namespace DarkMultiPlayer
 
         public void SendKerbalIfDifferent(ProtoCrewMember pcm)
         {
-            if (pcm.type == ProtoCrewMember.KerbalType.Tourist || (pcm.type == ProtoCrewMember.KerbalType.Unowned && pcm.rosterStatus == ProtoCrewMember.RosterStatus.Assigned))
-            {
-                //Don't send tourists/assigned & unowned kerbals (rescues)
-                DarkLog.Debug("Skipping sending of tourist or stranded: " + pcm.name);
-                return;
-            }
             ConfigNode kerbalNode = new ConfigNode();
             pcm.Save(kerbalNode);
+            if (pcm.type == ProtoCrewMember.KerbalType.Tourist || (pcm.type == ProtoCrewMember.KerbalType.Unowned && pcm.rosterStatus == ProtoCrewMember.RosterStatus.Assigned))
+            {
+                ConfigNode dmpNode = new ConfigNode();
+                dmpNode.AddValue("contractKerbalOwner", Settings.fetch.playerName);
+                kerbalNode.AddNode("DMP", dmpNode);
+            }
             byte[] kerbalBytes = ConfigNodeSerializer.fetch.Serialize(kerbalNode);
             if (kerbalBytes == null || kerbalBytes.Length == 0)
             {
@@ -1135,6 +1130,24 @@ namespace DarkMultiPlayer
                 DarkLog.Debug("crewNode is null!");
                 return;
             }
+
+            if (crewNode.GetValue("type") == "Tourist" || crewNode.GetValue("type") == "Unowned")
+            {
+                ConfigNode dmpNode = null;
+                if (crewNode.TryGetNode("DMP", ref dmpNode))
+                {
+                    string dmpOwner = null;
+                    if (dmpNode.TryGetValue("contractKerbalOwner", ref dmpOwner))
+                    {
+                        if (dmpOwner != Settings.fetch.playerName)
+                        {
+                            DarkLog.Debug("Skipping load of kerbal that belongs to another player's contracts");
+                            return;
+                        }
+                    }
+                }
+            }
+
             ProtoCrewMember protoCrew = new ProtoCrewMember(HighLogic.CurrentGame.Mode, crewNode);
             if (protoCrew == null)
             {
@@ -1146,7 +1159,6 @@ namespace DarkMultiPlayer
                 DarkLog.Debug("protoName is blank!");
                 return;
             }
-            protoCrew.type = ProtoCrewMember.KerbalType.Crew;
             if (!HighLogic.CurrentGame.CrewRoster.Exists(protoCrew.name))
             {
                 AddCrewMemberToRoster(protoCrew);
@@ -1213,6 +1225,19 @@ namespace DarkMultiPlayer
                     while (vesselQueue.Value.Count > 0)
                     {
                         VesselProtoUpdate vpu = vesselQueue.Value.Dequeue();
+                        ConfigNode dmpNode = null;
+                        if (vpu.vesselNode.TryGetNode("DMP", ref dmpNode))
+                        {
+                            string contractOwner = null;
+                            if (dmpNode.TryGetValue("contractOwner", ref contractOwner))
+                            {
+                                if (contractOwner != Settings.fetch.playerName)
+                                {
+                                    DarkLog.Debug("Skipping load of contract vessel that belongs to another player");
+                                    continue;
+                                }
+                            }
+                        }
                         ProtoVessel pv = CreateSafeProtoVesselFromConfigNode(vpu.vesselNode, vpu.vesselID);
                         if (pv != null && pv.vesselID == vpu.vesselID)
                         {
@@ -1434,7 +1459,7 @@ namespace DarkMultiPlayer
             try
             {
                 DodgeVesselActionGroups(inputNode);
-                RemoveManeuverNodesFromProtoVessel(inputNode);
+                //RemoveManeuverNodesFromProtoVessel(inputNode);
                 DodgeVesselLandedStatus(inputNode);
                 KerbalReassigner.fetch.DodgeKerbals(inputNode, protovesselID);
                 pv = new ProtoVessel(inputNode, HighLogic.CurrentGame);
@@ -1652,7 +1677,7 @@ namespace DarkMultiPlayer
             NetworkWorker.fetch.SendVesselRemove(dyingVesselID, false);
         }
 
-		//TODO: I don't know what this bool does?
+        //TODO: I don't know what this bool does?
         public void OnVesselRecovered(ProtoVessel recoveredVessel, bool something)
         {
             Guid recoveredVesselID = recoveredVessel.vesselID;
@@ -1787,7 +1812,7 @@ namespace DarkMultiPlayer
                     bool fromVesselUpdateLockIsOurs = LockSystem.fetch.LockIsOurs("update-" + partAction.from.vessel.id.ToString());
                     bool toVesselUpdateLockIsOurs = LockSystem.fetch.LockIsOurs("update-" + partAction.to.vessel.id.ToString());
                     if (fromVesselUpdateLockIsOurs || toVesselUpdateLockIsOurs || !fromVesselUpdateLockExists || !toVesselUpdateLockExists)
-                    {                    
+                    {
                         DarkLog.Debug("Vessel docking, from: " + partAction.from.vessel.id + ", name: " + partAction.from.vessel.vesselName);
                         DarkLog.Debug("Vessel docking, to: " + partAction.to.vessel.id + ", name: " + partAction.to.vessel.vesselName);
                         if (FlightGlobals.fetch.activeVessel != null)
@@ -2280,4 +2305,3 @@ namespace DarkMultiPlayer
         public ConfigNode kerbalNode;
     }
 }
-

--- a/Client/VesselWorker.cs
+++ b/Client/VesselWorker.cs
@@ -973,10 +973,10 @@ namespace DarkMultiPlayer
 
         public void SendKerbalIfDifferent(ProtoCrewMember pcm)
         {
-            if (pcm.type == ProtoCrewMember.KerbalType.Tourist)
+            if (pcm.type == ProtoCrewMember.KerbalType.Tourist || pcm.type == ProtoCrewMember.KerbalType.Unowned)
             {
-                //Don't send tourists
-                DarkLog.Debug("Skipping sending of tourist: " + pcm.name);
+                //Don't send tourists or unowned Kerbals (rescue)
+                DarkLog.Debug("Skipping sending of tourist/unowned: " + pcm.name);
                 return;
             }
             ConfigNode kerbalNode = new ConfigNode();
@@ -1570,6 +1570,7 @@ namespace DarkMultiPlayer
 
         public void OnVesselDestroyed(Vessel dyingVessel)
         {
+            //DarkLog.Debug("VesselWorker.OnVesselDestroyed: " + dyingVessel.vesselName);
             Guid dyingVesselID = dyingVessel.id;
             //Docking destructions
             if (dyingVesselID == fromDockedVesselID || dyingVesselID == toDockedVesselID)
@@ -1650,6 +1651,7 @@ namespace DarkMultiPlayer
 		//TODO: I don't know what this bool does?
         public void OnVesselRecovered(ProtoVessel recoveredVessel, bool something)
         {
+            DarkLog.Debug("VesselWorker.OnVesselRecovered");
             Guid recoveredVesselID = recoveredVessel.vesselID;
 
             if (LockSystem.fetch.LockExists("control-" + recoveredVesselID) && !LockSystem.fetch.LockIsOurs("control-" + recoveredVesselID))
@@ -1678,6 +1680,7 @@ namespace DarkMultiPlayer
 
         public void OnVesselTerminated(ProtoVessel terminatedVessel)
         {
+            DarkLog.Debug("VesselWorker.OnVesselTerminated");
             Guid terminatedVesselID = terminatedVessel.vesselID;
             //Check the vessel hasn't been changed in the future
             if (LockSystem.fetch.LockExists("control-" + terminatedVesselID) && !LockSystem.fetch.LockIsOurs("control-" + terminatedVesselID))


### PR DESCRIPTION
This will create kerbals and vessels for existing rescue contracts (which means, newly accepted contracts will have kerbals and vessels (re)created once the player disconnects then reconnects.

TODO: 
Save kerbals and vessels just spawned for new contracts (without reloading);
Properly remove kerbals and vessels for Expired, Failed and Cancelled/Declined contracts;
Handle contracts for rescuing *parts*;
Cleanup/improve the code.