### PR TITLE
Asteroids in 1.3

### DIFF
--- a/Client/AsteroidWorker.cs
+++ b/Client/AsteroidWorker.cs
@@ -70,7 +70,7 @@ namespace DarkMultiPlayer
                 orbit,
                 (uint)SentinelUtilities.RandomRange(random),
                 SentinelUtilities.WeightedAsteroidClass(random),
-                SentinelUtilities.RandomRange(random, baseDays, baseDays + orbit.period), baseDays * orbit.period);
+                double.PositiveInfinity, double.PositiveInfinity);
             return pv;
         }
 

--- a/Client/AsteroidWorker.cs
+++ b/Client/AsteroidWorker.cs
@@ -181,17 +181,15 @@ namespace DarkMultiPlayer
         /// <param name="checkVessel">The vessel to check</param>
         public bool VesselIsAsteroid(ProtoVessel checkVessel)
         {
-            if (checkVessel != null)
-            {
-                if (checkVessel.protoPartSnapshots != null ? (checkVessel.protoPartSnapshots.Count == 1) : false)
-                {
-                    if (checkVessel.protoPartSnapshots[0].partName == "PotatoRoid")
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
+            // Short circuit evaluation = faster
+            if (
+                checkVessel != null
+                && checkVessel.protoPartSnapshots != null
+                && checkVessel.protoPartSnapshots.Count == 1
+                && checkVessel.protoPartSnapshots[0].partName == "PotatoRoid")
+                return true;
+            else
+                return false;
         }
 
         private Vessel[] GetCurrentAsteroids()
@@ -209,25 +207,14 @@ namespace DarkMultiPlayer
 
         private int GetAsteroidCount()
         {
-            List<string> seenAsteroids = new List<string>();
-            foreach (Vessel checkAsteroid in GetCurrentAsteroids())
-            {
-                if (!seenAsteroids.Contains(checkAsteroid.id.ToString()))
-                {
-                    seenAsteroids.Add(checkAsteroid.id.ToString());
-                }
-            }
+            int asteroidCount = 0;
+            asteroidCount += GetCurrentAsteroids().Length;
             foreach (ProtoVessel checkAsteroid in HighLogic.CurrentGame.flightState.protoVessels)
             {
                 if (VesselIsAsteroid(checkAsteroid))
-                {
-                    if (!seenAsteroids.Contains(checkAsteroid.vesselID.ToString()))
-                    {
-                        seenAsteroids.Add(checkAsteroid.vesselID.ToString());
-                    }
-                }
+                    asteroidCount++;
             }
-            return seenAsteroids.Count;
+            return asteroidCount;
         }
 
         /// <summary>

--- a/Client/AsteroidWorker.cs
+++ b/Client/AsteroidWorker.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
+using SentinelMission;
 
 namespace DarkMultiPlayer
 {
@@ -11,8 +11,9 @@ namespace DarkMultiPlayer
         public bool workerEnabled;
         //private state variables
         private float lastAsteroidCheck;
-        private const float ASTEROID_CHECK_INTERVAL = 5f;
-        ScenarioDiscoverableObjects scenarioController;
+        private const float ASTEROID_CHECK_INTERVAL = 60f; // 1 minute
+        private ScenarioDiscoverableObjects scenario;
+        private bool initialized;
         private List<string> serverAsteroids = new List<string>();
         private Dictionary<string, string> serverAsteroidTrackStatus = new Dictionary<string, string>();
         private object serverAsteroidListLock = new object();
@@ -29,81 +30,98 @@ namespace DarkMultiPlayer
             this.networkWorker = networkWorker;
             this.vesselWorker = vesselWorker;
             this.dmpGame.updateEvent.Add(Update);
-            GameEvents.onGameSceneLoadRequested.Add(OnGameSceneLoadRequested);
             GameEvents.onVesselCreate.Add(OnVesselCreate);
+        }
+
+        public void InitializeScenario()
+        {
+            foreach (ProtoScenarioModule psm in HighLogic.CurrentGame.scenarios)
+            {
+                if (psm != null && scenario == null && psm.moduleName.Contains("Discoverable"))
+                {
+                    scenario = (ScenarioDiscoverableObjects)psm.moduleRef;  // this is borked as of 1.3.0; maybe they'll fix it in the future?
+                }
+            }
+            if (scenario != null) scenario.spawnInterval = float.MaxValue;
+
+            // Disable the new Sentinel mechanic in KSP 1.3.0
+            SentinelUtilities.SpawnChance = 0f;
+
+            initialized = true;
+        }
+
+        public IEnumerable<Vessel> SpawnAsteroids(int quantity = 1)
+        {
+            System.Random random = new System.Random();
+            while (quantity-- > 0)
+            {
+                yield return SpawnAsteroid(random).vesselRef;
+            }
+            yield break;
+        }
+
+        public ProtoVessel SpawnAsteroid(System.Random random)
+        {
+            double baseDays = 21 + random.NextDouble() * 360;
+            Orbit orbit = Orbit.CreateRandomOrbitFlyBy(Planetarium.fetch.Home, baseDays);
+
+            ProtoVessel pv = DiscoverableObjectsUtil.SpawnAsteroid(
+                DiscoverableObjectsUtil.GenerateAsteroidName(),
+                orbit,
+                (uint)SentinelUtilities.RandomRange(random),
+                SentinelUtilities.WeightedAsteroidClass(random),
+                SentinelUtilities.RandomRange(random, baseDays, baseDays + orbit.period), baseDays * orbit.period);
+            return pv;
         }
 
         private void Update()
         {
-            if (workerEnabled)
+            if (!workerEnabled) return;
+            if (Client.realtimeSinceStartup - lastAsteroidCheck < ASTEROID_CHECK_INTERVAL) return;
+                else lastAsteroidCheck = Client.realtimeSinceStartup;
+            if (!initialized) InitializeScenario();
+            
+            //Try to acquire the asteroid-spawning lock if nobody else has it.
+            if (!lockSystem.LockExists("asteroid-spawning"))
             {
-                if (scenarioController == null)
+                lockSystem.AcquireLock("asteroid-spawning", false);
+            }
+
+            //We have the spawn lock, lets do stuff.
+            if (lockSystem.LockIsOurs("asteroid-spawning"))
+            {
+                if ((HighLogic.CurrentGame.flightState.protoVessels != null) && (FlightGlobals.fetch.vessels != null))
                 {
-                    foreach (ProtoScenarioModule psm in HighLogic.CurrentGame.scenarios)
+                    if ((HighLogic.CurrentGame.flightState.protoVessels.Count == 0) || (FlightGlobals.fetch.vessels.Count > 0))
                     {
-                        if (psm != null)
+                        int beforeSpawn = GetAsteroidCount();
+                        int asteroidsToSpawn = maxNumberOfUntrackedAsteroids - beforeSpawn;
+                        if (asteroidsToSpawn > 0)
                         {
-                            if (psm.moduleName == "ScenarioDiscoverableObjects")
-                            {
-                                if (psm.moduleRef != null)
-                                {
-                                    scenarioController = (ScenarioDiscoverableObjects)psm.moduleRef;
-                                    scenarioController.spawnInterval = float.MaxValue;
-                                }
-                            }
+                            foreach (Vessel asty in SpawnAsteroids(1)) // spawn 1 every ASTEROID_CHECK_INTERVAL seconds
+                                DarkLog.Debug("Spawned asteroid " + asty.name + ", have " + (beforeSpawn) + ", need " + maxNumberOfUntrackedAsteroids);
                         }
                     }
                 }
+            }
 
-                if (scenarioController != null)
+            //Check for changes to tracking
+            foreach (Vessel asteroid in GetCurrentAsteroids())
+            {
+                if (asteroid.state != Vessel.State.DEAD)
                 {
-                    if ((Client.realtimeSinceStartup - lastAsteroidCheck) > ASTEROID_CHECK_INTERVAL)
+                    if (!serverAsteroidTrackStatus.ContainsKey(asteroid.id.ToString()))
                     {
-                        lastAsteroidCheck = Client.realtimeSinceStartup;
-                        //Try to acquire the asteroid-spawning lock if nobody else has it.
-                        if (!lockSystem.LockExists("asteroid-spawning"))
+                        serverAsteroidTrackStatus.Add(asteroid.id.ToString(), asteroid.DiscoveryInfo.trackingStatus.Value);
+                    }
+                    else
+                    {
+                        if (asteroid.DiscoveryInfo.trackingStatus.Value != serverAsteroidTrackStatus[asteroid.id.ToString()])
                         {
-                            lockSystem.AcquireLock("asteroid-spawning", false);
-                        }
-
-                        //We have the spawn lock, lets do stuff.
-                        if (lockSystem.LockIsOurs("asteroid-spawning"))
-                        {
-                            if ((HighLogic.CurrentGame.flightState.protoVessels != null) && (FlightGlobals.fetch.vessels != null))
-                            {
-                                if ((HighLogic.CurrentGame.flightState.protoVessels.Count == 0) || (FlightGlobals.fetch.vessels.Count > 0))
-                                {
-                                    int beforeSpawn = GetAsteroidCount();
-                                    int asteroidsToSpawn = maxNumberOfUntrackedAsteroids - beforeSpawn;
-                                    for (int asteroidsSpawned = 0; asteroidsSpawned < asteroidsToSpawn; asteroidsSpawned++)
-                                    {
-                                        DarkLog.Debug("Spawning asteroid, have " + (beforeSpawn + asteroidsSpawned) + ", need " + maxNumberOfUntrackedAsteroids);
-                                        scenarioController.SpawnAsteroid();
-                                    }
-                                }
-                            }
-                        }
-
-                        //Check for changes to tracking
-                        foreach (Vessel asteroid in GetCurrentAsteroids())
-                        {
-                            if (asteroid.state != Vessel.State.DEAD)
-                            {
-                                if (!serverAsteroidTrackStatus.ContainsKey(asteroid.id.ToString()))
-                                {
-                                    serverAsteroidTrackStatus.Add(asteroid.id.ToString(), asteroid.DiscoveryInfo.trackingStatus.Value);
-                                }
-                                else
-                                {
-                                    if (asteroid.DiscoveryInfo.trackingStatus.Value != serverAsteroidTrackStatus[asteroid.id.ToString()])
-                                    {
-                                        ProtoVessel pv = asteroid.BackupVessel();
-                                        DarkLog.Debug("Sending changed asteroid, new state: " + asteroid.DiscoveryInfo.trackingStatus.Value + "!");
-                                        serverAsteroidTrackStatus[asteroid.id.ToString()] = asteroid.DiscoveryInfo.trackingStatus.Value;
-                                        networkWorker.SendVesselProtoMessage(pv, false, false);
-                                    }
-                                }
-                            }
+                            ProtoVessel pv = asteroid.BackupVessel();
+                            DarkLog.Debug("Sending changed asteroid, new state: " + asteroid.DiscoveryInfo.trackingStatus.Value + "!");
+                            serverAsteroidTrackStatus[asteroid.id.ToString()] = asteroid.DiscoveryInfo.trackingStatus.Value;
+                            networkWorker.SendVesselProtoMessage(pv, false, false);
                         }
                     }
                 }
@@ -207,14 +225,7 @@ namespace DarkMultiPlayer
 
         private int GetAsteroidCount()
         {
-            int asteroidCount = 0;
-            asteroidCount += GetCurrentAsteroids().Length;
-            foreach (ProtoVessel checkAsteroid in HighLogic.CurrentGame.flightState.protoVessels)
-            {
-                if (VesselIsAsteroid(checkAsteroid))
-                    asteroidCount++;
-            }
-            return asteroidCount;
+            return GetCurrentAsteroids().Length;
         }
 
         /// <summary>
@@ -237,16 +248,9 @@ namespace DarkMultiPlayer
             }
         }
 
-        private void OnGameSceneLoadRequested(GameScenes scene)
-        {
-            //Force the worker to find the scenario module again.
-            scenarioController = null;
-        }
-
         public void Stop()
         {
             dmpGame.updateEvent.Remove(Update);
-            GameEvents.onGameSceneLoadRequested.Remove(OnGameSceneLoadRequested);
             GameEvents.onVesselCreate.Remove(OnVesselCreate);
         }
     }

--- a/Client/ScenarioWorker.cs
+++ b/Client/ScenarioWorker.cs
@@ -58,7 +58,6 @@ namespace DarkMultiPlayer
             if (contractNode.GetValue("type") == "RecoverAsset")
             {
                 string kerbalName = contractNode.GetValue("kerbalName").Trim();
-                int kerbalGender = int.Parse(contractNode.GetValue("gender"));
                 uint partID = uint.Parse(contractNode.GetValue("partID"));
 
                 if (!string.IsNullOrEmpty(kerbalName))
@@ -67,7 +66,7 @@ namespace DarkMultiPlayer
                     if (!HighLogic.CurrentGame.CrewRoster.Exists(kerbalName))
                     {
                         DarkLog.Debug("Generating missing kerbal " + kerbalName + " for rescue contract");
-
+                        int kerbalGender = int.Parse(contractNode.GetValue("gender"));
                         rescueKerbal = HighLogic.CurrentGame.CrewRoster.GetNewKerbal(ProtoCrewMember.KerbalType.Unowned);
                         rescueKerbal.ChangeName(kerbalName);
                         rescueKerbal.gender = (ProtoCrewMember.Gender)kerbalGender;
@@ -160,7 +159,7 @@ namespace DarkMultiPlayer
                 return false;
             }
             //Blacklist asteroid module from every game mode
-            if (scenarioName == "ScenarioDiscoverableObjects")
+            if (scenarioName == "DiscoverableObjects")
             {
                 //We hijack this and enable / disable it if we need to.
                 return false;


### PR DESCRIPTION
This is meant to temporarily solve the following issues

1) Squad has borked ProtoScenarioModule.moduleRef (intentionally or not), breaking the previous scenario detection / asteroid spawn inhibition. The old scenarios still exist, though asteroids are now generated by the SentinelModule. 
- The module's spawn coefficient was set to 0.

2) AsteroidWorker.Update() is called multiple times during load and all the time while the game is running. Existing asteroids were being recounted _very inefficiently_ during every Update() cycle, by iterating through *all* vessels and protovessels, checking if every one of them is an asteroid. Then adding every one of them to a List<>, instead of just generating the list once, and getting the total number of items from it (or just using a counter). 
- As iterating through vessels can't be avoided without probably a lot more work, the related methods have been optimized to reduce the number of calls.

3) All remaining asteroids up to the numberOfAsteroids set in Settings.txt were being generated at once by the first player that acquired the lock asteroid-spawning. On servers with asteroid generation increased and/or a high number of vessels, clients got stalled when loading the game while asteroids were being spawned; this along with (1) and (2) was causing apparent freezes on Syncing Vessels or the load screen, making players think the game froze (because it actually almost did, since the loop was running astray). 
- Along with the other fixes, the loop has been modified to spawn the asteroids on a much more relaxed rate of 1 per minute.

The current logic is just to keep the system working as it were pre-1.3 in DMP. 
Full compatibility with the new Sentinel scenario (esp. for career mode) will require a more complete refactoring of the Asteroid module to work with the fact asteroids in KSP are now generated in order to fulfill Sentinel contracts, and not just randomly.