### PR TITLE
Add SRCDS-style RCON implementation

### DIFF
--- a/Common/Common.cs
+++ b/Common/Common.cs
@@ -3,11 +3,72 @@ using System.Text;
 using System.Security.Cryptography;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DarkMultiPlayerCommon
 {
-    public class Common
+    public static class Common
     {
+        /// <summary>
+        /// Reverses a <see cref="List{byte}"/> if the <see cref="BitConverter"/> is Little-Endian
+        /// </summary>
+        /// <param name="list"></param>
+        /// <returns></returns>
+        public static List<byte> ReverseIfLittleEndian(this List<byte> list)
+        {
+            if (BitConverter.IsLittleEndian)
+                list.Reverse();
+            return list;
+        }
+
+        /// <summary>
+        /// Reverses a <see cref="byte[]"/> if the <see cref="BitConverter"/> is Little-Endian
+        /// </summary>
+        /// <param name="array"></param>
+        /// <returns></returns>
+        public static byte[] ReverseIfLittleEndian(this byte[] array)
+        {
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(array);
+            return array;
+        }
+
+        /// <summary>
+        /// Reverses a <see cref="List{byte}"/> if the <see cref="BitConverter"/> is Big-Endian
+        /// </summary>
+        /// <param name="list"></param>
+        /// <returns></returns>
+        public static List<byte> ReverseIfBigEndian(this List<byte> list)
+        {
+            if (!BitConverter.IsLittleEndian)
+                list.Reverse();
+            return list;
+        }
+
+        /// <summary>
+        /// Reverses a <see cref="byte[]"/> if the <see cref="BitConverter"/> is Big-Endian
+        /// </summary>
+        /// <param name="array"></param>
+        /// <returns></returns>
+        public static byte[] ReverseIfBigEndian(this byte[] array)
+        {
+            if (!BitConverter.IsLittleEndian)
+                Array.Reverse(array);
+            return array;
+        }
+
+        /// <summary>
+        /// Reads the next int from the collection and removes it
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public static int ReadNextInt(this List<byte> bytes)
+        {
+            int num = BitConverter.ToInt32(bytes.ToArray(), 0);
+            bytes.RemoveRange(0, 4);
+            return num;
+        }
+
         //Timeouts in milliseconds
         public const long HEART_BEAT_INTERVAL = 5000;
         public const long INITIAL_CONNECTION_TIMEOUT = 5000;

--- a/Common/Common.cs
+++ b/Common/Common.cs
@@ -9,66 +9,6 @@ namespace DarkMultiPlayerCommon
 {
     public static class Common
     {
-        /// <summary>
-        /// Reverses a <see cref="List{byte}"/> if the <see cref="BitConverter"/> is Little-Endian
-        /// </summary>
-        /// <param name="list"></param>
-        /// <returns></returns>
-        public static List<byte> ReverseIfLittleEndian(this List<byte> list)
-        {
-            if (BitConverter.IsLittleEndian)
-                list.Reverse();
-            return list;
-        }
-
-        /// <summary>
-        /// Reverses a <see cref="byte[]"/> if the <see cref="BitConverter"/> is Little-Endian
-        /// </summary>
-        /// <param name="array"></param>
-        /// <returns></returns>
-        public static byte[] ReverseIfLittleEndian(this byte[] array)
-        {
-            if (BitConverter.IsLittleEndian)
-                Array.Reverse(array);
-            return array;
-        }
-
-        /// <summary>
-        /// Reverses a <see cref="List{byte}"/> if the <see cref="BitConverter"/> is Big-Endian
-        /// </summary>
-        /// <param name="list"></param>
-        /// <returns></returns>
-        public static List<byte> ReverseIfBigEndian(this List<byte> list)
-        {
-            if (!BitConverter.IsLittleEndian)
-                list.Reverse();
-            return list;
-        }
-
-        /// <summary>
-        /// Reverses a <see cref="byte[]"/> if the <see cref="BitConverter"/> is Big-Endian
-        /// </summary>
-        /// <param name="array"></param>
-        /// <returns></returns>
-        public static byte[] ReverseIfBigEndian(this byte[] array)
-        {
-            if (!BitConverter.IsLittleEndian)
-                Array.Reverse(array);
-            return array;
-        }
-
-        /// <summary>
-        /// Reads the next int from the collection and removes it
-        /// </summary>
-        /// <param name="bytes"></param>
-        /// <returns></returns>
-        public static int ReadNextInt(this List<byte> bytes)
-        {
-            int num = BitConverter.ToInt32(bytes.ToArray(), 0);
-            bytes.RemoveRange(0, 4);
-            return num;
-        }
-
         //Timeouts in milliseconds
         public const long HEART_BEAT_INTERVAL = 5000;
         public const long INITIAL_CONNECTION_TIMEOUT = 5000;

--- a/Server/CommandHandler.cs
+++ b/Server/CommandHandler.cs
@@ -66,8 +66,17 @@ namespace DarkMultiPlayerServer
             }
         }
 
-        public static void HandleServerInput(string input)
+        public static void HandleServerInput(string input, RCON.CommandCallback outputCallback = null)
         {
+            // capture command output for RCON
+            // this might capture unrelated output, but this is the only way without rewriting the command handling system
+            List<string> commandOutput = new List<string>();
+            void OnLog(string message)
+            {
+                commandOutput.Add(message);
+            };
+            DarkLog.OnLog += OnLog;
+
             string commandPart = input;
             string argumentPart = "";
             if (commandPart.Contains(" "))
@@ -96,6 +105,12 @@ namespace DarkMultiPlayerServer
                     DarkLog.Normal("Unknown server command: " + commandPart);
                 }
             }
+
+            // remove event listener
+            DarkLog.OnLog -= OnLog;
+
+            // send output back to rcon
+            outputCallback?.Invoke(string.Join("\n", commandOutput));
         }
 
         public static void RegisterCommand(string command, Action<string> func, string description)

--- a/Server/Extensions.cs
+++ b/Server/Extensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DarkMultiPlayerServer
+{
+    /// <summary>
+    /// Contains extension methods
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        /// Reverses a <see cref="byte[]"/> if the <see cref="BitConverter"/> is Big-Endian
+        /// </summary>
+        /// <param name="array"></param>
+        /// <returns></returns>
+        public static byte[] ReverseIfBigEndian(this byte[] array)
+        {
+            if (!BitConverter.IsLittleEndian)
+                Array.Reverse(array);
+            return array;
+        }
+
+        /// <summary>
+        /// Reads the next int from the collection and removes it
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public static int ReadNextInt(this List<byte> bytes)
+        {
+            int num = BitConverter.ToInt32(bytes.ToArray(), 0);
+            bytes.RemoveRange(0, 4);
+            return num;
+        }
+    }
+}

--- a/Server/Log.cs
+++ b/Server/Log.cs
@@ -8,6 +8,8 @@ namespace DarkMultiPlayerServer
         public static string LogFolder = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "logs");
         public static string LogFilename = Path.Combine(LogFolder, "dmpserver " + DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss") + ".log");
         private static object logLock = new object();
+        public delegate void OnLogEventHandler(string logText);
+        public static event OnLogEventHandler OnLog;
 
         public enum LogLevels
         {
@@ -40,6 +42,7 @@ namespace DarkMultiPlayerServer
                 {
                     Console.WriteLine(output);
                     Messages.Chat.SendConsoleMessageToAdmins(output);
+                    OnLog?.Invoke(output);
                 }
                 try
                 {

--- a/Server/Main.cs
+++ b/Server/Main.cs
@@ -172,6 +172,14 @@ namespace DarkMultiPlayerServer
                 }
 
                 StartHTTPServer();
+
+                // start RCON server
+                if (Settings.settingsStore.rconEnabled)
+                {
+                    DarkLog.Debug("Starting RCON server on port " + Settings.settingsStore.rconPort);
+                    RCON.Start();
+                }
+
                 DarkLog.Normal("Ready!");
                 DMPPluginHandler.FireOnServerStart();
                 while (serverRunning)

--- a/Server/RCON.cs
+++ b/Server/RCON.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using DarkMultiPlayerCommon;
+
+namespace DarkMultiPlayerServer
+{
+    /// <summary>
+    /// A system to use SRCDS-style RCON commands.
+    /// </summary>
+    public static class RCON
+    {
+        public delegate void CommandReceivedEventHandler(object sender, RconCommandEventArgs e);
+        public static event CommandReceivedEventHandler CommandReceived;
+
+        private static bool _running;
+        private static TcpListener _tcpListener;
+        private static List<RCONClient> _clients = new List<RCONClient>();
+
+        /// <summary>
+        /// Start the RCON server
+        /// </summary>
+        public static void Start()
+        {
+            _tcpListener = new TcpListener(new IPEndPoint(IPAddress.Any, Settings.settingsStore.rconPort));
+
+            _tcpListener.Start();
+            _running = true;
+            _tcpListener.BeginAcceptTcpClient(AcceptTcpClient, null);
+
+            DarkLog.Normal("Started RCON server on port " + Settings.settingsStore.rconPort);
+        }
+
+        private static void AcceptTcpClient(IAsyncResult ar)
+        {
+            if (!_running)
+                return;
+
+            TcpClient tcpClient = _tcpListener.EndAcceptTcpClient(ar);
+            RCONClient client = new RCONClient(tcpClient);
+
+            DarkLog.Normal("RCON connection from " + ((IPEndPoint)client.TcpClient.Client.RemoteEndPoint).Address.ToString());
+            _clients.Add(client);
+
+            // accept another client
+            _tcpListener.BeginAcceptTcpClient(AcceptTcpClient, null);
+        }
+
+        public static void ProcessCommand(RCONClient client, string command)
+        {
+            CommandReceived?.Invoke(client, new RconCommandEventArgs()
+            {
+                CommandText = command,
+                OriginIP = ((IPEndPoint)client.TcpClient.Client.RemoteEndPoint).Address
+            });
+        }
+    }
+
+    public class RCONClient
+    {
+        public RCONClientState State { get; set; }
+        public TcpClient TcpClient;
+        public IPAddress RemoteIP
+        {
+            get
+            {
+                return ((IPEndPoint)TcpClient.Client.RemoteEndPoint).Address;
+            }
+        }
+
+        public RCONClient(TcpClient client)
+        {
+            TcpClient = client;
+            State = RCONClientState.UNAUTHENTICATED;
+
+            Thread readThread = new Thread(ReadLoop)
+            {
+                IsBackground = true,
+                Name = "RCON Client Read Thread (" + RemoteIP.ToString() + ")"
+            };
+            readThread.Start();
+        }
+
+        private void ReadLoop()
+        {
+            while (TcpClient.Connected)
+            {
+                lock (TcpClient)
+                {
+                    List<byte> packetRaw;
+                    // read data from stream
+                    try
+                    {
+                        byte[] lengthRaw = ReadBytes(4);
+                        int length = BitConverter.ToInt32(lengthRaw.ReverseIfBigEndian(), 0);
+                        packetRaw = new List<byte>(lengthRaw);
+                        packetRaw.AddRange(ReadBytes(length));
+                    }
+                    catch (Exception)   // client disconnected
+                    {
+                        Close();
+                        return;
+                    }
+
+                    // turn data into a packet and process it 
+                    HandlePacket(new RCONPacket()
+                    {
+                        RawData = packetRaw
+                    });
+                }
+            }
+        }
+
+        private byte[] ReadBytes(int amount)
+        {
+            byte[] buffer = new byte[amount];
+            int bytesRead = 0;
+
+            while (bytesRead < amount)
+            {
+                int j = TcpClient.GetStream().Read(buffer, bytesRead, amount - bytesRead);
+
+                if (j == 0) // client disconnected
+                {
+                    Close();
+                    throw new Exception("Socket closed");
+                }
+
+                bytesRead += j;
+            }
+
+            return buffer;
+        }
+
+        public void SendPacket(RCONPacket p)
+        {
+            lock (TcpClient)
+            {
+                TcpClient.GetStream().Write(p.RawData.ToArray(), 0, p.RawData.Count);
+            }
+        }
+
+        public void Close()
+        {
+            TcpClient.Close();
+        }
+
+        private void HandlePacket(RCONPacket packet)
+        {
+            switch (packet.Type)
+            {
+                case RCONPacketType.SERVERDATA_AUTH:
+                    bool authenticated = packet.Body == Settings.settingsStore.rconPassword;
+
+                    // send response
+                    SendPacket(new RCONPacket()
+                    {
+                        ID = (authenticated ? packet.ID : -1),  // match packet id if pass good, otherwise -1
+                        Type = RCONPacketType.SERVERDATA_AUTH_RESPONSE
+                    });
+
+                    if (authenticated)
+                        State = RCONClientState.AUTHENTICATED;
+
+                    break;
+                case RCONPacketType.SERVERDATA_EXECCOMMAND: // command
+                    if (State != RCONClientState.AUTHENTICATED)
+                    {
+                        // not authenticated
+                        Close();
+                        break;
+                    }
+                    RCON.ProcessCommand(this, packet.Body); // run command
+                    DarkLog.Normal("RCON command from " + RemoteIP.ToString() + ": " + packet.Body);
+                    // TODO: send command response
+                    break;
+            }
+        }
+    }
+
+    public class RCONPacket
+    {
+        public List<byte> RawData
+        {
+            get
+            {
+                // create builder for packet
+                List<byte> builder = new List<byte>(BitConverter.GetBytes(Size).ReverseIfBigEndian());   // packet size
+                builder.AddRange(BitConverter.GetBytes(ID).ReverseIfBigEndian());   // packet id
+                builder.AddRange(BitConverter.GetBytes((int)Type).ReverseIfBigEndian()); // packet type
+                builder.AddRange(Encoding.ASCII.GetBytes(Body));
+                builder.AddRange(new byte[2]);  // packet suffix
+
+                return builder;
+            }
+            set
+            {
+                List<byte> buffer = value;
+                int size = buffer.ReadNextInt();
+                ID = buffer.ReadNextInt();
+                Type = (RCONPacketType)buffer.ReadNextInt();
+                Body = Encoding.ASCII.GetString(buffer.ToArray(), 0, (size - 10));  // subtract size of header + suffix
+            }
+        }
+
+        public int Size
+        {
+            get
+            {
+                // https://developer.valvesoftware.com/wiki/Source_RCON_Protocol#Packet_Size
+                return Encoding.ASCII.GetBytes(Body).Length + 10;
+            }
+        }
+
+        public int ID { get; set; } = 0;
+
+        public RCONPacketType Type { get; set; }
+
+        public string Body { get; set; } = "";
+    }
+
+    public class RconCommandEventArgs : EventArgs
+    {
+        public string CommandText { get; set; }
+        public IPAddress OriginIP { get; set; }
+    }
+
+    public enum RCONPacketType
+    {
+        SERVERDATA_AUTH = 3,
+        SERVERDATA_AUTH_RESPONSE = 2,
+        SERVERDATA_EXECCOMMAND = 2,
+        SERVERDATA_RESPONSE_VALUE = 0
+    }
+
+    public enum RCONClientState
+    {
+        /// <summary>
+        /// Clients that have not yet authenticated
+        /// </summary>
+        UNAUTHENTICATED,
+        /// <summary>
+        /// Clients that have successfully authenticated
+        /// </summary>
+        AUTHENTICATED,
+    }
+}

--- a/Server/RCON.cs
+++ b/Server/RCON.cs
@@ -153,10 +153,7 @@ namespace DarkMultiPlayerServer
         /// <param name="packet"></param>
         public void SendPacket(RCONPacket packet)
         {
-            lock (TcpClient)
-            {
-                TcpClient.GetStream().Write(packet.RawData.ToArray(), 0, packet.RawData.Count);
-            }
+            TcpClient.GetStream().Write(packet.RawData.ToArray(), 0, packet.RawData.Count);
         }
 
         /// <summary>
@@ -303,7 +300,7 @@ namespace DarkMultiPlayerServer
                 Body = Encoding.ASCII.GetString(buffer.ToArray(), 0, (size - 10));  // subtract size of header + suffix
             }
         }
-        
+
         /// <summary>
         /// The size of the packet in bytes, not including the size field
         /// </summary>

--- a/Server/RCON.cs
+++ b/Server/RCON.cs
@@ -61,9 +61,20 @@ namespace DarkMultiPlayerServer
                 return;
 
             TcpClient tcpClient = _tcpListener.EndAcceptTcpClient(ar);
+
+            // check if IP is on banlist
+            if (BanSystem.fetch.IsIPBanned(((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address))
+            {
+                DarkLog.Normal("Refused RCON connection from " + ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address.ToString() + " (IP Banned)");
+                tcpClient.Close();
+                _tcpListener.BeginAcceptTcpClient(AcceptTcpClient, null);
+                return;
+            }
+
             RCONClient client = new RCONClient(tcpClient);
 
             DarkLog.Normal("RCON connection from " + client.RemoteIP.ToString());
+
             Clients.Add(client);
             client.Start();
 

--- a/Server/RCON.cs
+++ b/Server/RCON.cs
@@ -166,6 +166,7 @@ namespace DarkMultiPlayerServer
         public void SendPacket(RCONPacket packet)
         {
             TcpClient.GetStream().Write(packet.RawData.ToArray(), 0, packet.RawData.Count);
+            TcpClient.GetStream().Flush();
         }
 
         /// <summary>

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -40,6 +40,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
     <Compile Include="GameplaySettings.cs" />
     <Compile Include="LogExpire.cs" />
     <Compile Include="Main.cs" />

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Main.cs" />
     <Compile Include="CommandHandler.cs" />
     <Compile Include="ClientHandler.cs" />
+    <Compile Include="RCON.cs" />
     <Compile Include="ScreenshotExpire.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="Log.cs" />

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -42,6 +42,12 @@ namespace DarkMultiPlayerServer
         public string address = "0.0.0.0";
         [Description("The port the server listens on.")]
         public int port = 6702;
+        [Description("Whether to enabled SRCDS-style RCON (Remote Console)")]
+        public bool rconEnabled = false;
+        [Description("The password to use for RCON.\n# WARNING: Anyone with this password can access your server console and have full control over your server!\n# Change this before enabling RCON")]
+        public string rconPassword = "changeme";
+        [Description("The port to use for RCON connections.")]
+        public int rconPort = 6703;
         [Description("Specify the warp type.")]
         public WarpMode warpMode = WarpMode.SUBSPACE;
         [Description("Specify the game type.")]


### PR DESCRIPTION
Hi! I just started using this server to play with my friends and I love this project! I thought it would be very useful to have a way to control my server remotely in case I'm not able to access the machine my server is running on. To solve this, I implemented [SRCDS-styled RCON](https://developer.valvesoftware.com/wiki/Source_RCON_Protocol) (Remote Console). It's the most widely used protocol for game servers and has many clients that support it. One popular client can be found [here](https://sourceforge.net/projects/ssrcdsrcon/).

It integrates almost seamlessly with the existing command handlers and comes disabled by default. It starts a new TcpListener on a new port (6703 by default) and allows server admins to control the server from virtually anywhere. As the most popular multiplayer mod for KSP, I believe having a solid RCON implementation for the server is essential.

I hope you consider my addition, and I'd love to answer any questions you may have.