### PR TITLE
newVesselProtection setting

### DIFF
--- a/Server/Permissions.cs
+++ b/Server/Permissions.cs
@@ -226,6 +226,7 @@ namespace DarkMultiPlayerServer
                 if (!vesselPermissions.ContainsKey(guid))
                 {
                     SetVesselOwner(guid, owner);
+                    SetVesselProtection(guid, Settings.settingsStore.newVesselProtection);
                 }
             }
         }

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -94,5 +94,7 @@ namespace DarkMultiPlayerServer
         public double expireLogs = 0;
         [Description("Specify the minimum distance in which vessels can interact with eachother at the launch pad and runway")]
         public float safetyBubbleDistance = 100.0f;
+        [Description("Specify which protection mode to set new vessels to.")]
+        public VesselProtectionType newVesselProtection = VesselProtectionType.PUBLIC;
     }
 }


### PR DESCRIPTION
Adds a setting which changes the protection mode on new vessels, with public still being the default.