### PR TITLE
Fixed inconsistent decimal point be using explicit format info.

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -155,7 +155,6 @@
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
-    <PostBuildEvent Condition="'$(OS)' != 'Unix'">$(SolutionDir)/pdb2mdb/pdb2mdb.exe $(ProjectDir)/$(OutDir)/DarkMultiPlayer.dll
 $(SolutionDir)/pdb2mdb/pdb2mdb.exe $(ProjectDir)/$(OutDir)/DarkMultiPlayer-Common.dll</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Client/Utilities/CompatibilityChecker.cs
+++ b/Client/Utilities/CompatibilityChecker.cs
@@ -49,7 +49,7 @@ namespace DarkMultiPlayer.Utilities
         public static bool IsCompatible()
         {
             const int compatibleMajor = 1;
-            const int compatibleMinor = 9;
+            const int compatibleMinor = 8;
             //const int compatibleRevision = 2;
             return (Versioning.version_major == compatibleMajor) && (Versioning.version_minor == compatibleMinor);
 

--- a/Server/Messages/WarpControl.cs
+++ b/Server/Messages/WarpControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Globalization;
 using DarkMultiPlayerCommon;
 using MessageStream2;
 
@@ -609,7 +610,7 @@ namespace DarkMultiPlayerServer.Messages
                     Subspace savedSubspace = new Subspace();
                     int subspaceID = Int32.Parse(firstLine);
                     savedSubspace.serverClock = Int64.Parse(sr.ReadLine().Trim());
-                    savedSubspace.planetTime = Double.Parse(sr.ReadLine().Trim());
+                    savedSubspace.planetTime = Double.Parse(sr.ReadLine().Trim(), new CultureInfo("en-US"));
                     savedSubspace.subspaceSpeed = Single.Parse(sr.ReadLine().Trim());
                     subspaces.Add(subspaceID, savedSubspace);
                     lock (createLock)
@@ -674,7 +675,7 @@ namespace DarkMultiPlayerServer.Messages
                 sw.WriteLine("#Each variable is on a new line. They are subspaceID, server clock (from DateTime.UtcNow.Ticks), universe time, and subspace speed.");
                 sw.WriteLine(subspaceID);
                 sw.WriteLine(subspace.serverClock);
-                sw.WriteLine(subspace.planetTime);
+                sw.WriteLine(subspace.planetTime.ToString(new CultureInfo("en-US")));
                 sw.WriteLine(subspace.subspaceSpeed);
             }
         }


### PR DESCRIPTION
Fixes a bug when running a server on certain locales where Double.Parse would behave differently to StreamWriter.WriteLine(). After a bit of testing this should do the trick. possibly needs to be addressed in VesselInfo as well at some Point. 
https://github.com/godarklight/DarkMultiPlayer/blob/3ce17b66ee3ffb69f1ca68ba650734dd292a3c46/Client/VesselWorker.cs#L1935
