### PR TITLE
Add setting to disable IPv6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 saves/
 .vs/
 .vscode/
+.idea/
 External/KSPManaged/*.dll

--- a/Server/ClientHandler.cs
+++ b/Server/ClientHandler.cs
@@ -89,7 +89,13 @@ namespace DarkMultiPlayerServer
             {
                 IPAddress bindAddress = IPAddress.Parse(Settings.settingsStore.address);
                 TCPServer = new TcpListener(new IPEndPoint(bindAddress, Settings.settingsStore.port));
-                TCPServer.Server.DualMode = true;
+                
+                // This if statement is required. Even setting it to `false` causes an exception if the system does not support IPv6
+                if (Settings.settingsStore.supportIpv6)
+                {
+                    TCPServer.Server.DualMode = true;   
+                }
+                
                 TCPServer.Start(4);
                 TCPServer.BeginAcceptTcpClient(new AsyncCallback(NewClientCallback), null);
             }

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -42,6 +42,8 @@ namespace DarkMultiPlayerServer
         public string address = "0.0.0.0";
         [Description("The port the server listens on.")]
         public int port = 6702;
+        [Description("Whether the server should listen on IPv4 AND IPv6.\nSet this to False if you see the following error: \"Error setting up server, Exception: System.NotSupportedException: This protocol version is not supported.\"")]
+        public bool supportIpv6 = true;
         [Description("Specify the modpack type.\nNONE: DMPClients cannot download modpacks from this server\nCKAN: DMPServer will send the clients Config/DarkMultiPlayer.ckan upon connecting, informing them of changes\nGAMEDATA: DMPServer will send the clients Config/GameData\nNote: They still need to run DMPModpackUpdater in order to actually install the modpack as GameData cannot be modified while KSP is running")]
         public ModpackMode modpackMode = ModpackMode.NONE;
         [Description("Specify the warp type.")]


### PR DESCRIPTION
I was trying to run DMP in a Docker container, but it kept throwing `System.NotSupportedException: This protocol version is not supported.` on `TCPServer.Server.DualMode = true;`.  
If your system does not support IPv6, which my Docker server seems to not, you cannot start the server.

I added a setting to disable IPv6 to circumvent this. The default behavior is the same as before, only a setting was added to disable it.

As commented in the code, I'm not sure why, but if I do
```csharp
TCPServer.Server.DualMode = Settings.settingsStore.supportIpv6;
```
even if it was set to `false`, it would crash. So I had to add an if statement that only set it to true if IPv6 is enabled, and doesn't do anything if it's not.